### PR TITLE
feat: add screen transition animation 

### DIFF
--- a/screens/src/home/home-screen.tsx
+++ b/screens/src/home/home-screen.tsx
@@ -1,29 +1,18 @@
-import { useNavigation } from '@react-navigation/native'
 import { Screen } from '@silo-component/screen'
 import { Text } from '@silo-component/text'
-import { AppHeader } from '@silo-feature/app-header'
 import { IncomingSilos } from '@silo-feature/incoming-silos'
-import { NavBar } from '@silo-feature/nav-bar'
 import { COLOR_X } from '@silo-feature/theme'
 import { Spacer } from 'native-x-spacer'
 import { Stack } from 'native-x-stack'
 import { COLOR } from 'native-x-theme'
 import React from 'react'
 import { StatusBar } from 'react-native'
-import { Modals } from '../navigation/modals'
 
 export function HomeScreen() {
-  const { navigate } = useNavigation<any>()
-  const openCodeScanner = React.useCallback(() => {
-    navigate(Modals.CodeScanner)
-  }, [navigate])
-
   return (
     <Screen withSafeArea={false}>
       <StatusBar barStyle='light-content' backgroundColor='#235039' animated />
-
       <Stack fill backgroundColor={COLOR.PRIMARY}>
-        <AppHeader />
         <Stack alignCenter fill padding='normal' backgroundColor={COLOR_X.PAGE}>
           <Spacer size='small' />
           <Text fill fontSize='large' textColor={COLOR.TERTIARY} semiBold>
@@ -31,7 +20,6 @@ export function HomeScreen() {
           </Text>
           <IncomingSilos />
         </Stack>
-        <NavBar onScanIconTap={openCodeScanner} />
       </Stack>
     </Screen>
   )

--- a/screens/src/home/home-stack.tsx
+++ b/screens/src/home/home-stack.tsx
@@ -1,0 +1,40 @@
+import { useNavigation } from '@react-navigation/native'
+import {
+  createStackNavigator,
+  StackNavigationOptions,
+  TransitionPresets,
+} from '@react-navigation/stack'
+import { AppHeader } from '@silo-feature/app-header'
+import { NavBar } from '@silo-feature/nav-bar'
+import React from 'react'
+import { LotDetailsScreen } from '../lot-details/lot-details-screen'
+import { Modals } from '../navigation/modals'
+import { Screens } from '../navigation/screens'
+import { PurchaseOrderScreen } from '../purchase-order/purchase-order-screen'
+import { HomeScreen } from './home-screen'
+
+const { Navigator, Screen } = createStackNavigator()
+
+const screenOptions: StackNavigationOptions = {
+  headerShown: false,
+  animationEnabled: true,
+  ...TransitionPresets.SlideFromRightIOS,
+}
+
+export function HomeStack() {
+  const { navigate } = useNavigation<any>()
+  const openCodeScanner = React.useCallback(() => {
+    navigate(Modals.CodeScanner)
+  }, [navigate])
+  return (
+    <>
+      <AppHeader />
+      <Navigator screenOptions={screenOptions}>
+        <Screen name={Screens.Home} component={HomeScreen} />
+        <Screen name={Screens.PurchaseOrder} component={PurchaseOrderScreen} />
+        <Screen name={Screens.LotDetails} component={LotDetailsScreen} />
+      </Navigator>
+      <NavBar onScanIconTap={openCodeScanner} />
+    </>
+  )
+}

--- a/screens/src/login/login-screen.tsx
+++ b/screens/src/login/login-screen.tsx
@@ -17,7 +17,7 @@ const styles = {
 
 export function LoginScreen() {
   const { navigate } = useNavigation<any>()
-  const navigateToHome = useCallback(() => navigate(Screens.Home), [navigate])
+  const navigateToHome = useCallback(() => navigate(Screens.HomeTab), [navigate])
   const hideSplashScreen = useCallback(() => SplashScreen.hide(), [])
 
   return (

--- a/screens/src/lot-details/lot-details-screen.tsx
+++ b/screens/src/lot-details/lot-details-screen.tsx
@@ -2,9 +2,7 @@ import { useNavigation } from '@react-navigation/native'
 import { PageHeader } from '@silo-component/page-header'
 import { Screen } from '@silo-component/screen'
 import { Text } from '@silo-component/text'
-import { AppHeader } from '@silo-feature/app-header'
 import { LotDetails } from '@silo-feature/lot-details'
-import { NavBar } from '@silo-feature/nav-bar'
 import { COLOR_X } from '@silo-feature/theme'
 import { Spacer } from 'native-x-spacer'
 import { Stack } from 'native-x-stack'
@@ -16,26 +14,21 @@ export function LotDetailsScreen() {
   const { goBack } = useNavigation<any>()
 
   return (
-    <>
-      <AppHeader />
-
-      <Screen withSafeArea backgroundColor={COLOR.PRIMARY}>
-        <Spacer />
-        <Spacer size='small' />
-        <PageHeader showBackButton accentColor={COLOR_X.ACCENT4} onTapLeftButton={goBack}>
-          <Stack horizontal alignMiddle fill alignCenter>
-            <LotIcon />
-            <Spacer size='x-small' />
-            <Text semiBold fontSize='x-large' textColor={COLOR.PRIMARY}>
-              LOT #ANG-001617
-            </Text>
-          </Stack>
-        </PageHeader>
-        <Stack fill backgroundColor={COLOR_X.PAGE} padding='vertical:x-small'>
-          <LotDetails />
+    <Screen withSafeArea backgroundColor={COLOR.PRIMARY}>
+      <Spacer />
+      <Spacer size='small' />
+      <PageHeader showBackButton accentColor={COLOR_X.ACCENT4} onTapLeftButton={goBack}>
+        <Stack horizontal alignMiddle fill alignCenter>
+          <LotIcon />
+          <Spacer size='x-small' />
+          <Text semiBold fontSize='x-large' textColor={COLOR.PRIMARY}>
+            LOT #ANG-001617
+          </Text>
         </Stack>
-      </Screen>
-      <NavBar />
-    </>
+      </PageHeader>
+      <Stack fill backgroundColor={COLOR_X.PAGE} padding='vertical:x-small'>
+        <LotDetails />
+      </Stack>
+    </Screen>
   )
 }

--- a/screens/src/navigation/screens.tsx
+++ b/screens/src/navigation/screens.tsx
@@ -1,7 +1,5 @@
 import { ById } from '@silo/util'
-import { HomeScreen } from '../home/home-screen'
-import { LotDetailsScreen } from '../lot-details/lot-details-screen'
-import { PurchaseOrderScreen } from '../purchase-order/purchase-order-screen'
+import { HomeStack } from '../home/home-stack'
 
 export enum Screens {
   Main = 'MAIN',
@@ -9,12 +7,13 @@ export enum Screens {
   Home = 'HOME_SCREEN',
   LotDetails = 'LOT_DETAILS',
   Error = 'ERROR',
-  PurchaseOrder = 'PurchaseOrder',
+  PurchaseOrder = 'PURCHASE_ORDER',
+  HomeTab = 'HOME_TAB',
 }
 
 export type MainStackParamList = {
   [Screens.Login]: undefined
-  [Screens.Home]: undefined
+  [Screens.HomeTab]: undefined
 }
 
 type ScreenConfigType = {
@@ -26,16 +25,9 @@ type ScreenConfigType = {
 
 const publicScreens: ById<ScreenConfigType> = {}
 const mainScreens: ById<ScreenConfigType> = {
-  [Screens.Home]: {
-    screen: HomeScreen,
-    initialRouteName: Screens.Home,
-  },
-  [Screens.PurchaseOrder]: {
-    screen: PurchaseOrderScreen,
-  },
-  [Screens.LotDetails]: {
-    screen: LotDetailsScreen,
-    initialRouteName: Screens.Home,
+  [Screens.HomeTab]: {
+    screen: HomeStack,
+    initialRouteName: Screens.HomeTab,
   },
 }
 

--- a/screens/src/purchase-order/purchase-order-screen.tsx
+++ b/screens/src/purchase-order/purchase-order-screen.tsx
@@ -2,8 +2,6 @@ import { useNavigation } from '@react-navigation/native'
 import { PageHeader } from '@silo-component/page-header'
 import { Screen } from '@silo-component/screen'
 import { Text } from '@silo-component/text'
-import { AppHeader } from '@silo-feature/app-header'
-import { NavBar } from '@silo-feature/nav-bar'
 import { PurchaseOrder } from '@silo-feature/purchase-order'
 import { COLOR_X } from '@silo-feature/theme'
 import { Spacer } from 'native-x-spacer'
@@ -19,25 +17,21 @@ export function PurchaseOrderScreen() {
   const navigateToLotDetails = React.useCallback(() => navigate(Screens.LotDetails), [navigate])
 
   return (
-    <>
-      <AppHeader />
-      <Screen withSafeArea>
-        <Stack fill backgroundColor={COLOR_X.PAGE}>
-          <Spacer />
-          <Spacer size='small' />
-          <PageHeader showBackButton accentColor={COLOR.SUCCESS} onTapLeftButton={navigateToHome}>
-            <Stack horizontal alignMiddle fill alignCenter>
-              <PurchaseOrderIcon />
-              <Spacer size='small' />
-              <Text semiBold fontSize='x-large' textColor={COLOR.PRIMARY}>
-                PO # 65444
-              </Text>
-            </Stack>
-          </PageHeader>
-          <PurchaseOrder onSelectLot={navigateToLotDetails} />
-          <NavBar />
-        </Stack>
-      </Screen>
-    </>
+    <Screen withSafeArea>
+      <Stack fill backgroundColor={COLOR_X.PAGE}>
+        <Spacer />
+        <Spacer size='small' />
+        <PageHeader showBackButton accentColor={COLOR.SUCCESS} onTapLeftButton={navigateToHome}>
+          <Stack horizontal alignMiddle fill alignCenter>
+            <PurchaseOrderIcon />
+            <Spacer size='small' />
+            <Text semiBold fontSize='x-large' textColor={COLOR.PRIMARY}>
+              PO # 65444
+            </Text>
+          </Stack>
+        </PageHeader>
+        <PurchaseOrder onSelectLot={navigateToLotDetails} />
+      </Stack>
+    </Screen>
   )
 }


### PR DESCRIPTION
## Description

This PR adds horizontal slide transition animation while navigating from home to po and to lot details screens.

### Change log

- Combine home, po & lot details screens under a stack navigator
- Replace homescreen with home stack

### Screenshots

https://user-images.githubusercontent.com/6880914/155205870-cd389d55-40df-44e2-bacf-ff74294aef3b.mp4



