### PR TITLE
feat: add app banner

### DIFF
--- a/feature/config/src/dev.json
+++ b/feature/config/src/dev.json
@@ -1,7 +1,8 @@
 {
   "env": "dev",
   "app": {
-    "urlScheme": "usesilo-dev://"
+    "urlScheme": "usesilo-dev://",
+    "publicURL":"https://stage.usesilo.com"
   },
   "api": {
     "version": "1.0.0",

--- a/feature/config/src/dev.json
+++ b/feature/config/src/dev.json
@@ -2,7 +2,7 @@
   "env": "dev",
   "app": {
     "urlScheme": "usesilo-dev://",
-    "publicURL":"https://stage.usesilo.com"
+    "publicURL": "https://stage.usesilo.com"
   },
   "api": {
     "version": "1.0.0",

--- a/feature/config/src/index.ts
+++ b/feature/config/src/index.ts
@@ -10,6 +10,7 @@ export interface FrontendConfig {
 
 export interface App {
   urlScheme: string
+  publicURL: string
 }
 
 export interface API {

--- a/feature/config/src/local.json
+++ b/feature/config/src/local.json
@@ -1,7 +1,8 @@
 {
   "env": "dev",
   "app": {
-    "urlScheme": "usesilo-dev://"
+    "urlScheme": "usesilo-dev://",
+    "publicURL":"https://stage.usesilo.com"
   },
   "api": {
     "version": "1.0.0",

--- a/feature/config/src/local.json
+++ b/feature/config/src/local.json
@@ -2,7 +2,7 @@
   "env": "dev",
   "app": {
     "urlScheme": "usesilo-dev://",
-    "publicURL":"https://stage.usesilo.com"
+    "publicURL": "https://stage.usesilo.com"
   },
   "api": {
     "version": "1.0.0",

--- a/feature/config/src/prod.json
+++ b/feature/config/src/prod.json
@@ -2,7 +2,7 @@
   "env": "prod",
   "app": {
     "urlScheme": "usesilo://",
-    "publicURL":"https://usesilo.com"
+    "publicURL": "https://usesilo.com"
   },
   "api": {
     "version": "1.0.0",

--- a/feature/config/src/prod.json
+++ b/feature/config/src/prod.json
@@ -1,7 +1,8 @@
 {
   "env": "prod",
   "app": {
-    "urlScheme": "usesilo://"
+    "urlScheme": "usesilo://",
+    "publicURL":"https://usesilo.com"
   },
   "api": {
     "version": "1.0.0",

--- a/screens/src/login/app-banner.tsx
+++ b/screens/src/login/app-banner.tsx
@@ -1,0 +1,58 @@
+import { Text } from '@silo-component/text'
+import config from '@silo-feature/config'
+import { COLOR_X } from '@silo-feature/theme'
+import { Spacer } from 'native-x-spacer'
+import { Stack } from 'native-x-stack'
+import { COLOR } from 'native-x-theme'
+import React from 'react'
+import { Dimensions, Linking, StyleSheet } from 'react-native'
+
+const {
+  app: { publicURL },
+} = config
+
+export function AppBanner() {
+  const navigateToSiloWeb = () => Linking.openURL(publicURL)
+  return (
+    <Stack style={styles.wrapper}>
+      <Stack backgroundColor={COLOR_X.ACCENT3} style={styles.banner} />
+      <Stack fillHorizontal padding='large' style={styles.bannerText}>
+        <Spacer />
+        <Text fill lineHeight='solid' textColor={COLOR.PRIMARY} alignCenter>
+          The world’s first adaptive food platform is here for a more connected, efficient food
+          service.
+        </Text>
+        <Spacer size='small' />
+        <Spacer size='x-small' />
+        <Text textColor={COLOR.PRIMARY} alignCenter>
+          Not in Silo yet?{' '}
+          <Text bold onPress={navigateToSiloWeb}>
+            Learn more here
+          </Text>
+        </Text>
+        <Spacer size='small' />
+      </Stack>
+    </Stack>
+  )
+}
+
+const { width, height } = Dimensions.get('screen')
+const BANNER_HEIGHT = 250
+const styles = StyleSheet.create({
+  wrapper: {
+    height: BANNER_HEIGHT,
+    position: 'absolute',
+    top: height - BANNER_HEIGHT,
+    width,
+  },
+  bannerText: { top: 0, position: 'absolute' },
+  banner: {
+    borderTopLeftRadius: BANNER_HEIGHT,
+    borderTopRightRadius: BANNER_HEIGHT,
+    height: BANNER_HEIGHT,
+    position: 'absolute',
+    top: 0,
+    transform: [{ scaleX: 2.0 }],
+    width,
+  },
+})

--- a/screens/src/login/login-screen.tsx
+++ b/screens/src/login/login-screen.tsx
@@ -8,6 +8,7 @@ import { COLOR } from 'native-x-theme'
 import React, { useCallback } from 'react'
 import { KeyboardAvoidingView, ScrollView, StatusBar } from 'react-native'
 import SplashScreen from 'react-native-splash-screen'
+import { AppBanner } from './app-banner'
 
 const styles = {
   container: { flex: 1 },
@@ -20,8 +21,8 @@ export function LoginScreen() {
     <Background onLoad={hideSplashScreen}>
       <Screen backgroundColor={COLOR.TRANSPARENT} withSafeArea>
         <StatusBar barStyle='light-content' backgroundColor='#192820' animated />
-        <ScrollView>
-          <KeyboardAvoidingView behavior='position' style={styles.container}>
+        <ScrollView keyboardShouldPersistTaps='handled'>
+          <KeyboardAvoidingView style={styles.container} behavior='position'>
             <Stack fill alignCenter padding='normal'>
               <Spacer size='large' />
               <Logo />
@@ -30,6 +31,7 @@ export function LoginScreen() {
             </Stack>
           </KeyboardAvoidingView>
         </ScrollView>
+        <AppBanner />
       </Screen>
     </Background>
   )


### PR DESCRIPTION
## Description

Adds app description banner at the bottom of login screen

## Screenshot

![image](https://user-images.githubusercontent.com/6880914/157648698-4190f0e1-19ce-4767-b4fa-4586e91127ee.png)


NB: In design banner uses same accent color that we've used for buttons. So I used a darker green as the banner background. Feel free to change as needed.