### PR TITLE
feat: add search option to outgoing orders screen

### DIFF
--- a/feature/sales-order/src/sales-order-list.tsx
+++ b/feature/sales-order/src/sales-order-list.tsx
@@ -1,23 +1,49 @@
+import { Button } from '@silo-component/button'
 import { DataView } from '@silo-component/data-view'
+import { FilterIcon, SearchIcon } from '@silo-component/icons'
 import { Text } from '@silo-component/text'
 import { COLOR_X } from '@silo-feature/theme'
 import { Spacer } from 'native-x-spacer'
 import { Stack } from 'native-x-stack'
 import { Tappable } from 'native-x-tappable'
+import { COLOR } from 'native-x-theme'
 import React from 'react'
 import { FlatList } from 'react-native'
 import { EmptyView } from './empty-view'
 import { SalesOrderListItemView } from './sales-order-list-item-view'
 import { SalesOrderSearchResult } from './use-sales-order-search-query'
-
 interface Props {
+  searchActive?: boolean
   orders?: Array<SalesOrderSearchResult>
   loading?: boolean
   error?: Error | null
   onSelect?: (id: number) => void
+  onSearchIconTap?: () => void
+  onClearSearchTap?: () => void
+  onFilterIconTap?: () => void
 }
 
-export function SalesOrderList({ orders, loading, error, onSelect }: Props) {
+export function SalesOrderList({
+  orders,
+  loading,
+  error,
+  searchActive,
+  onSelect,
+  onClearSearchTap,
+  onSearchIconTap,
+  onFilterIconTap,
+}: Props) {
+  const renderHeader = React.useCallback(
+    () => (
+      <Header
+        searchActive={searchActive}
+        onSearch={onSearchIconTap}
+        onFilter={onFilterIconTap}
+        onClearSearchTap={onClearSearchTap}
+      />
+    ),
+    [searchActive, onClearSearchTap, onFilterIconTap, onSearchIconTap],
+  )
   const renderItem = React.useCallback(
     ({ item }: { item: SalesOrderSearchResult }) => (
       <Tappable data={item.salesOrderID} onTap={onSelect}>
@@ -31,12 +57,12 @@ export function SalesOrderList({ orders, loading, error, onSelect }: Props) {
   )
   return (
     <Stack fill>
-      {!orders ? <Header /> : null}
+      {!orders ? renderHeader() : null}
       <DataView fill isLoading={loading} error={error} data={orders} emptyMessage={<EmptyView />}>
         <FlatList
           data={orders}
           renderItem={renderItem}
-          ListHeaderComponent={<Header />}
+          ListHeaderComponent={renderHeader()}
           ListFooterComponent={<Spacer size='large' />}
         />
       </DataView>
@@ -44,15 +70,47 @@ export function SalesOrderList({ orders, loading, error, onSelect }: Props) {
   )
 }
 
-function Header() {
+function Header({
+  searchActive,
+  onSearch,
+  onFilter,
+  onClearSearchTap,
+}: {
+  searchActive?: boolean
+  onClearSearchTap?: () => void
+  onSearch?: () => void
+  onFilter?: () => void
+}) {
   return (
     <Stack padding='normal' fillHorizontal>
       <Spacer size='xx-small' />
-      <Text fill fontSize='x-large' textColor={COLOR_X.ACCENT3}>
-        Outgoing
-      </Text>
+      <Stack alignMiddle horizontal fillHorizontal>
+        <Text fontSize='x-large' textColor={COLOR_X.ACCENT3}>
+          {searchActive ? 'Results' : 'Outgoing'}
+        </Text>
+        <Spacer fill />
+        {searchActive ? (
+          <Button clear textColor={COLOR.TERTIARY} size='small' onTap={onClearSearchTap}>
+            Clear Search
+          </Button>
+        ) : null}
+        <Tappable onTap={onSearch}>
+          <SearchIcon />
+        </Tappable>
+
+        {!searchActive ? (
+          <>
+            <Spacer />
+            <Spacer size='x-small' />
+            <Tappable onTap={onFilter}>
+              <FilterIcon />
+            </Tappable>
+          </>
+        ) : null}
+        <Spacer size='x-small' />
+      </Stack>
       <Spacer size='small' />
-      <Text textColor={COLOR_X.ACCENT2}>List of SOs</Text>
+      <Text textColor={COLOR_X.ACCENT2}>{searchActive ? 'Search Results' : 'List of SOs'}</Text>
     </Stack>
   )
 }

--- a/feature/sales-order/src/sales-orders.tsx
+++ b/feature/sales-order/src/sales-orders.tsx
@@ -4,14 +4,33 @@ import { SalesOrderList } from './sales-order-list'
 import { useSalesOrderSearchQuery } from './use-sales-order-search-query'
 
 interface Props {
+  id?: string
+  invoiceNumber?: string
+  purchaseOrderNumber?: string
   from?: Date
   to?: Date
   onSelect?: (id: number) => void
+  onSearchIconTap?: () => void
+  onClearSearchTap?: () => void
+  onFilterIconTap?: () => void
 }
 
-export function SalesOrders({ from, to, onSelect }: Props) {
+export function SalesOrders({
+  id,
+  invoiceNumber,
+  purchaseOrderNumber,
+  from,
+  to,
+  onSelect,
+  onSearchIconTap,
+  onClearSearchTap,
+  onFilterIconTap,
+}: Props) {
   const { user } = useAuth()
   const { data, isLoading, error } = useSalesOrderSearchQuery({
+    id,
+    purchaseOrderNumber,
+    invoiceNumber,
     userID: user?.userID,
     startDate: from,
     endDate: to,
@@ -19,10 +38,14 @@ export function SalesOrders({ from, to, onSelect }: Props) {
 
   return (
     <SalesOrderList
+      searchActive={!!(id || purchaseOrderNumber || invoiceNumber)}
       loading={isLoading}
       orders={data?.salesOrders}
       error={error}
       onSelect={onSelect}
+      onClearSearchTap={onClearSearchTap}
+      onSearchIconTap={onSearchIconTap}
+      onFilterIconTap={onFilterIconTap}
     />
   )
 }

--- a/feature/sales-order/src/use-sales-order-search-query.ts
+++ b/feature/sales-order/src/use-sales-order-search-query.ts
@@ -1,6 +1,9 @@
 import { useQuery } from '@silo-feature/api'
 
 interface SearchRequest {
+  id?: string
+  purchaseOrderNumber?: string
+  invoiceNumber?: string
   userID?: number
   startDate?: Date
   endDate?: Date
@@ -32,10 +35,29 @@ interface SalesOrderSearchResponse {
   salesOrders: Array<SalesOrderSearchResult>
 }
 
-export function useSalesOrderSearchQuery({ userID, startDate, endDate }: SearchRequest) {
+export function useSalesOrderSearchQuery({
+  userID,
+  id,
+  invoiceNumber,
+  purchaseOrderNumber,
+  startDate,
+  endDate,
+}: SearchRequest) {
   const params = new URLSearchParams('')
   params.append('order', 'ID')
   params.append('sortDirection', 'desc')
+
+  if (id) {
+    params.append('salesOrderID', id)
+  }
+
+  if (purchaseOrderNumber) {
+    params.append('customerPONumber', purchaseOrderNumber)
+  }
+
+  if (invoiceNumber) {
+    params.append('invoiceNumber', invoiceNumber)
+  }
 
   if (userID) {
     params.append('userID', userID.toString())
@@ -51,7 +73,7 @@ export function useSalesOrderSearchQuery({ userID, startDate, endDate }: SearchR
 
   return useQuery<SalesOrderSearchResponse>(
     `/seller/sales_orders/search?${params.toString()}`,
-    'SalesOrders',
+    `salesOrders:${id}:${purchaseOrderNumber}:${invoiceNumber}`,
     {
       enabled: !!userID,
     },

--- a/screens/src/home/home-screen.tsx
+++ b/screens/src/home/home-screen.tsx
@@ -14,20 +14,20 @@ import { Screens } from '../navigation/screens'
 type HomeScreenParamList = {
   [Screens.Home]: {
     id?: string
-    customerInvoiceNumber?: string
+    invoiceNumber?: string
     purchaseOrderNumber?: string
   }
 }
 
 export function HomeScreen({ navigation }: StackScreenProps<any>) {
   const { params } = useRoute<RouteProp<HomeScreenParamList>>()
-  const { id, customerInvoiceNumber, purchaseOrderNumber } = params ?? {}
+  const { id, invoiceNumber, purchaseOrderNumber } = params ?? {}
 
   const navigateToPurchaseOrderDetails = (orderId: number) => {
     navigation.navigate(Screens.HomeTab, { screen: Screens.PurchaseOrder, params: { id: orderId } })
   }
   const navigateToSearch = () => {
-    navigation.navigate(Modals.Search)
+    navigation.navigate(Modals.Search, { target: Screens.Home })
   }
   const navigateToFilters = () => {
     navigation.navigate(Modals.Filters)
@@ -44,7 +44,7 @@ export function HomeScreen({ navigation }: StackScreenProps<any>) {
           <Spacer size='large' />
           <PurchaseOrders
             id={id}
-            customerInvoiceNumber={customerInvoiceNumber}
+            customerInvoiceNumber={invoiceNumber}
             purchaseOrderNumber={purchaseOrderNumber}
             onSelect={navigateToPurchaseOrderDetails}
             onClearSearchTap={clearSearchParams}

--- a/screens/src/outgoing-orders/outgoing-orders-home.tsx
+++ b/screens/src/outgoing-orders/outgoing-orders-home.tsx
@@ -1,3 +1,4 @@
+import { RouteProp, useRoute } from '@react-navigation/core'
 import type { StackScreenProps } from '@react-navigation/stack'
 import { Screen } from '@silo-component/screen'
 import { SalesOrders } from '@silo-feature/sales-order'
@@ -7,19 +8,52 @@ import { Stack } from 'native-x-stack'
 import { COLOR } from 'native-x-theme'
 import React from 'react'
 import { StatusBar } from 'react-native'
+import { Modals } from '../navigation/modals'
 import { Screens } from '../navigation/screens'
 
-export function OutgoingOrdersHomeScreen({ navigation }: StackScreenProps<any>) {
-  const navigateToSalesOrderDetails = (id: number) => {
-    navigation.navigate(Screens.OutgoingOrdersTab, { screen: Screens.SalesOrder, params: { id } })
+type OutgoingOrdersHomeParamList = {
+  [Screens.Home]: {
+    id?: string
+    invoiceNumber?: string
+    purchaseOrderNumber?: string
   }
+}
+
+export function OutgoingOrdersHomeScreen({ navigation }: StackScreenProps<any>) {
+  const { params } = useRoute<RouteProp<OutgoingOrdersHomeParamList>>()
+  const { id, invoiceNumber, purchaseOrderNumber } = params ?? {}
+  const navigateToSearch = () => {
+    navigation.navigate(Modals.Search, { target: Screens.OutgoingOrdersHome })
+  }
+  const navigateToFilters = () => {
+    navigation.navigate(Modals.Filters)
+  }
+  const clearSearchParams = () => {
+    navigation.navigate(Screens.OutgoingOrdersHome)
+  }
+
+  const navigateToSalesOrderDetails = (orderId: number) => {
+    navigation.navigate(Screens.OutgoingOrdersTab, {
+      screen: Screens.SalesOrder,
+      params: { id: orderId },
+    })
+  }
+
   return (
     <Screen>
       <StatusBar barStyle='light-content' backgroundColor='#235039' animated />
       <Stack fill backgroundColor={COLOR.PRIMARY}>
         <Stack alignCenter fill backgroundColor={COLOR_X.PAGE}>
           <Spacer size='large' />
-          <SalesOrders onSelect={navigateToSalesOrderDetails} />
+          <SalesOrders
+            id={id}
+            onSelect={navigateToSalesOrderDetails}
+            invoiceNumber={invoiceNumber}
+            purchaseOrderNumber={purchaseOrderNumber}
+            onClearSearchTap={clearSearchParams}
+            onSearchIconTap={navigateToSearch}
+            onFilterIconTap={navigateToFilters}
+          />
         </Stack>
       </Stack>
     </Screen>

--- a/screens/src/search/search-modal.tsx
+++ b/screens/src/search/search-modal.tsx
@@ -13,8 +13,17 @@ import { COLOR } from 'native-x-theme'
 import React, { useEffect } from 'react'
 import { Modal } from 'react-native'
 import { Screens } from '../navigation/screens'
+import { useRoute, RouteProp } from '@react-navigation/core'
+import { Modals } from '../navigation/modals'
+
+type SearchModalParamList = {
+  [Modals.Search]: {
+    target?: Screens
+  }
+}
 
 export function SearchModal() {
+  const { params } = useRoute<RouteProp<SearchModalParamList>>()
   const [searchKey, setSearchKey] = React.useState<string>('')
   const [searchBy, setSearchBy] = React.useState<string>('id')
   const [visible, open, close] = useOpenClose(true)
@@ -31,14 +40,16 @@ export function SearchModal() {
       },
       {
         label: 'Invoice number',
-        value: 'customerInvoiceNumber',
+        value: 'invoiceNumber',
       },
     ],
     [],
   )
   const onSearchTap = () => {
     close()
-    navigate({ name: Screens.Home, params: { [searchBy]: searchKey }, merge: true })
+    if (params.target) {
+      navigate({ name: params.target, params: { [searchBy]: searchKey }, merge: true })
+    }
   }
 
   const onClose = () => {

--- a/screens/src/search/search-modal.tsx
+++ b/screens/src/search/search-modal.tsx
@@ -1,3 +1,4 @@
+import { RouteProp, useRoute } from '@react-navigation/core'
 import { useNavigation } from '@react-navigation/native'
 import { SearchIcon } from '@silo-component/icons'
 import { Picker } from '@silo-component/picker'
@@ -12,9 +13,8 @@ import { Tappable } from 'native-x-tappable'
 import { COLOR } from 'native-x-theme'
 import React, { useEffect } from 'react'
 import { Modal } from 'react-native'
-import { Screens } from '../navigation/screens'
-import { useRoute, RouteProp } from '@react-navigation/core'
 import { Modals } from '../navigation/modals'
+import { Screens } from '../navigation/screens'
 
 type SearchModalParamList = {
   [Modals.Search]: {


### PR DESCRIPTION
## Description

This PR adds search options to outgoing orders tab.

### Change log

- Make search modal reusable across PO & SO screens
- Add search fields to sales-order-search query
- Add search feature to outgoing orders screen

### Screenshots

https://user-images.githubusercontent.com/6880914/164094993-fb250428-6885-4857-a563-4270103a7840.mp4


